### PR TITLE
Add isEmpty for singly and doubly linked lists

### DIFF
--- a/src/data/mutable/DoublyLinkedList.scala
+++ b/src/data/mutable/DoublyLinkedList.scala
@@ -34,6 +34,15 @@ class DoublyLinkedList[T] {
     */
   var last: Node[T] = null
 
+  /** Checks if the doubly linked list is empty.
+    *
+    * @return
+    *   `true` if the list is empty (head is null, which also implies last is null), `false`
+    *   otherwise.
+    */
+  def isEmpty: Boolean =
+    head == null
+
   /** Inserts a new node with the given data at the beginning (head) of the list. Updates both the
     * `next` pointer of the new node and the `prev` pointer of the former head. If the list is
     * empty, the new node becomes both the head and the last node.
@@ -43,7 +52,7 @@ class DoublyLinkedList[T] {
     */
   def insertHead(newData: T): Unit = {
     val newNode = Node(newData)
-    if (head == null) {
+    if (isEmpty) {
       head = newNode
       last = newNode
     } else {
@@ -62,7 +71,7 @@ class DoublyLinkedList[T] {
     */
   def insertLast(newData: T): Unit = {
     val newNode = Node(newData)
-    if (last == null) {
+    if (isEmpty) {
       head = newNode
       last = newNode
     } else {
@@ -81,7 +90,7 @@ class DoublyLinkedList[T] {
     *   The data of the former head.
     */
   def extractHead(): T =
-    if (head == null)
+    if (isEmpty)
       throw new NoSuchElementException("Cannot extract head from an empty list")
     else {
       val data = head.data
@@ -102,7 +111,7 @@ class DoublyLinkedList[T] {
     *   The data of the former last node.
     */
   def extractLast(): T =
-    if (last == null)
+    if (isEmpty)
       throw new NoSuchElementException("Cannot extract last from an empty list")
     else {
       val data = last.data

--- a/src/data/mutable/SinglyLinkedList.scala
+++ b/src/data/mutable/SinglyLinkedList.scala
@@ -28,6 +28,14 @@ class SinglyLinkedList[T] {
     */
   var head: Node[T] = null
 
+  /** Checks if the linked list is empty.
+    *
+    * @return
+    *   `true` if the list is empty (head is null), `false` otherwise.
+    */
+  def isEmpty: Boolean =
+    head == null
+
   /** Inserts a new node with the given data at the beginning (head) of the list.
     *
     * @param newData
@@ -47,7 +55,7 @@ class SinglyLinkedList[T] {
     *   The data of the former head.
     */
   def extractHead(): T =
-    if (head == null)
+    if (isEmpty)
       throw new NoSuchElementException("Cannot extract head from an empty list")
     else {
       val data = head.data

--- a/test/src/data/mutable/DoublyLinkedListTest.scala
+++ b/test/src/data/mutable/DoublyLinkedListTest.scala
@@ -3,6 +3,20 @@ package scalacs.data.mutable
 import munit.FunSuite
 
 class DoublyLinkedListSuite extends FunSuite {
+  test("isEmpty should return true for an empty list") {
+    val list = new DoublyLinkedList[Int]()
+    assert(list.isEmpty)
+  }
+
+  test("isEmpty should return false for a non-empty list") {
+    val list = new DoublyLinkedList[String]()
+    list.insertHead("hello")
+    assert(!list.isEmpty)
+
+    list.extractHead()
+    list.insertLast("world")
+    assert(!list.isEmpty)
+  }
 
   test("insertHead should add a new element to the beginning of the list") {
     val list = new DoublyLinkedList[Int]()

--- a/test/src/data/mutable/SinglyLinkedListTest.scala
+++ b/test/src/data/mutable/SinglyLinkedListTest.scala
@@ -1,6 +1,17 @@
 package scalacs.data.mutable
 
 class SinglyLinkedListSuite extends munit.FunSuite {
+  test("isEmpty should return true for an empty list") {
+    val list = new SinglyLinkedList[Int]()
+    assert(list.isEmpty)
+  }
+
+  test("isEmpty should return false for a non-empty list") {
+    val list = new SinglyLinkedList[String]()
+    list.insertHead("hello")
+    assert(!list.isEmpty)
+  }
+
   test("insertHead should add a new element to the beginning of the list") {
     val list = new SinglyLinkedList[Int]()
     list.insertHead(1)


### PR DESCRIPTION
Since extract... throws NoSuchElementException if the list is empty, it should have a method to inspect this before extracting.